### PR TITLE
fix: Workaround running out of memory with cargo updating index from scratch in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM rust:1.61.0 AS build
 
+# We have to use sparse-registry nightly cargo feature to avoid running out of RAM:
+# https://github.com/rust-lang/cargo/issues/10781
+RUN rustup toolchain install nightly
+
 WORKDIR /tmp/
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo +nightly build -Z sparse-registry
 COPY ./src ./src
-RUN cargo build --offline
+RUN cargo +nightly build -Z sparse-registry --offline
 
 
 FROM ubuntu:20.04


### PR DESCRIPTION
Ref: https://github.com/rust-lang/cargo/issues/10781