### PR TITLE
fix(docker): Fixed docker release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN rustup toolchain install nightly
 
 WORKDIR /tmp/
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo +nightly build -Z sparse-registry --release
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo +nightly build -Z sparse-registry --release && rm -r src
 COPY ./src ./src
 RUN cargo +nightly build -Z sparse-registry --offline --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /tmp/
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -r src
 COPY ./src ./src
+# NOTE: We need to touch main.rs file in order to force cargo incremental compilation to pick up, otherwise it keeps an empty app
 RUN touch src/main.rs && cargo build --offline --release
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM rust:1.61.0 AS build
-
-# We have to use sparse-registry nightly cargo feature to avoid running out of RAM:
-# https://github.com/rust-lang/cargo/issues/10781
-RUN rustup toolchain install nightly
+FROM rust:1.62 AS build
 
 WORKDIR /tmp/
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo +nightly build -Z sparse-registry --release && rm -r src
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && cargo build --release && rm -r src
 COPY ./src ./src
-RUN cargo +nightly build -Z sparse-registry --offline --release
+RUN touch src/main.rs && cargo build --offline --release
 
 
 FROM ubuntu:20.04


### PR DESCRIPTION
It seems that cargo incremental compilation gets confused by the `main.rs` file that is older than the temporary file, and so we need to explicitly touch the file after we copy it in order to properly compile the project.