### PR TITLE
IPE-354: Replace 'tracing' with 'env_logger' for getting more logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ actix-web-prom = "0.6.0"
 borsh = { version = "0.9.1" }
 derive_more = "0.99.9"
 dotenv = "0.15.0"
+env_logger= "0.9"
 futures = "0.3.5"
 hex = "0.4"
+log = "0.4"
 num-traits = "0.2.15"
 # https://github.com/paperclip-rs/paperclip/pull/458
 # Without this fix, the header auth token is exposed as bearer JWT token
@@ -26,8 +28,6 @@ serde_json = "1"
 strum = { version = "0.24", features = ["derive"] }
 sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres", "bigdecimal", "json"] }
 tokio = { version = "1.1", features = ["full"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 validator = { version = "0.14", features = ["derive"] }
 
 near-primitives = "0.14.0"

--- a/src/db_helpers.rs
+++ b/src/db_helpers.rs
@@ -150,7 +150,7 @@ pub(crate) async fn select_retry_or_panic<T: Send + Unpin + for<'r> sqlx::FromRo
     let mut interval = INTERVAL;
     let mut retry_attempt = 0usize;
 
-    tracing::info!(
+    log::info!(
         target: crate::LOGGER_MSG,
         "DB request:\n{}\nParams:{}",
         query,
@@ -177,7 +177,7 @@ pub(crate) async fn select_retry_or_panic<T: Send + Unpin + for<'r> sqlx::FromRo
         {
             Ok(res) => return Ok(res),
             Err(async_error) => {
-                tracing::warn!(
+                log::warn!(
                     target: crate::LOGGER_MSG,
                     "Error occurred during {:#?}:\nFailed SELECT:\n{}Params:{}\n Retrying in {} milliseconds...",
                     async_error,

--- a/src/rpc_helpers.rs
+++ b/src/rpc_helpers.rs
@@ -26,7 +26,7 @@ pub(crate) async fn wrapped_call(
     block_height: u64,
     contract_id: &near_primitives::types::AccountId,
 ) -> crate::Result<near_primitives::views::CallResult> {
-    tracing::info!(
+    log::info!(
         target: crate::LOGGER_MSG,
         "RPC request: {:?}\nTo contract:{}, block {}",
         request,


### PR DESCRIPTION
- This changes makes other middlewares to add to the logs by default. We also get the request and response payloads and status code for the response. 