### PR TITLE
fix: Allow to properly configure production API server URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "paperclip"
 version = "0.7.1"
-source = "git+https://github.com/near/paperclip?branch=fix/security-schema-v3-translation#50d11b96f302abc83237749fce279bcf3ca4f16d"
+source = "git+https://github.com/near/paperclip?branch=feat/respect-host-in-v2-to-v3-servers-conversion#e9b0cec02e8d059cf4d465f0bc48027d1a7250f5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -1897,7 +1897,7 @@ dependencies = [
  "paperclip-actix",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "semver",
  "serde",
  "serde_derive",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "paperclip-actix"
 version = "0.5.1"
-source = "git+https://github.com/near/paperclip?branch=fix/security-schema-v3-translation#50d11b96f302abc83237749fce279bcf3ca4f16d"
+source = "git+https://github.com/near/paperclip?branch=feat/respect-host-in-v2-to-v3-servers-conversion#e9b0cec02e8d059cf4d465f0bc48027d1a7250f5"
 dependencies = [
  "actix-service",
  "actix-web",
@@ -1919,14 +1919,14 @@ dependencies = [
  "openapiv3",
  "paperclip-core",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "serde_json",
 ]
 
 [[package]]
 name = "paperclip-core"
 version = "0.5.2"
-source = "git+https://github.com/near/paperclip?branch=fix/security-schema-v3-translation#50d11b96f302abc83237749fce279bcf3ca4f16d"
+source = "git+https://github.com/near/paperclip?branch=feat/respect-host-in-v2-to-v3-servers-conversion#e9b0cec02e8d059cf4d465f0bc48027d1a7250f5"
 dependencies = [
  "actix-web",
  "actix-web-validator",
@@ -1935,7 +1935,7 @@ dependencies = [
  "once_cell",
  "openapiv3",
  "paperclip-macros",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "pin-project",
  "regex",
  "serde",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "paperclip-macros"
 version = "0.6.1"
-source = "git+https://github.com/near/paperclip?branch=fix/security-schema-v3-translation#50d11b96f302abc83237749fce279bcf3ca4f16d"
+source = "git+https://github.com/near/paperclip?branch=feat/respect-host-in-v2-to-v3-servers-conversion#e9b0cec02e8d059cf4d465f0bc48027d1a7250f5"
 dependencies = [
  "heck",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ dotenv = "0.15.0"
 futures = "0.3.5"
 hex = "0.4"
 num-traits = "0.2.15"
-# https://github.com/paperclip-rs/paperclip/pull/458
-# Without this fix, the header auth token is exposed as bearer JWT token
-paperclip = { git = "https://github.com/near/paperclip", branch = "fix/security-schema-v3-translation", features = ["v2", "v3", "actix4", "actix4-validator"] }
+# https://github.com/paperclip-rs/paperclip/pull/463
+# Without this fix, the API URL won't be set properly
+paperclip = { git = "https://github.com/near/paperclip", branch = "feat/respect-host-in-v2-to-v3-servers-conversion", features = ["v2", "v3", "actix4", "actix4-validator"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.24", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,8 +101,6 @@ async fn main() -> std::io::Result<()> {
         cors_allowed_origins,
         limits,
     } = config::Config::default();
-    let api_server_public_host =
-        std::env::var("API_SERVER_PUBLIC_HOST").unwrap_or_else(|_| addr.clone());
 
     let server = HttpServer::new(move || {
         let json_config = web::JsonConfig::default()
@@ -128,26 +126,12 @@ async fn main() -> std::io::Result<()> {
         });
 
         let mut spec = paperclip::v2::models::DefaultApiRaw::default();
-        spec.schemes
-            .insert(paperclip::v2::models::OperationProtocol::Https);
-        spec.schemes
-            .insert(paperclip::v2::models::OperationProtocol::Http);
-        spec.host = Some(api_server_public_host.clone());
+        if let Ok(api_server_public_host) = std::env::var("API_SERVER_PUBLIC_HOST") {
+            spec.schemes
+                .insert(paperclip::v2::models::OperationProtocol::Https);
+            spec.host = Some(api_server_public_host);
+        }
         spec.base_path = Some("/".to_string());
-        spec.tags = vec![
-            paperclip::v2::models::Tag {
-                name: "Accounts".to_string(),
-                description: Some("Most common actions with accounts in NEAR".to_string()),
-                external_docs: None,
-            },
-            paperclip::v2::models::Tag {
-                name: "Standards".to_string(),
-                description: Some(
-                    "Manipulate with NEAR Enhancement Proposal (NEP) Standards".to_string(),
-                ),
-                external_docs: None,
-            },
-        ];
         spec.info = paperclip::v2::models::Info {
             version: "0.1".into(),
             title: "NEAR Enhanced API powered by Pagoda".into(),


### PR DESCRIPTION
Without this fix the API server URL will be taken from the URL user navigates to the page from (see core.dev.console.pagoda.co), and it won't work for obvious reasons (that is not the server which should handle Enhanced API requests):

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/304265/187766019-6f6e9ec9-3121-4882-8000-f7fcd55b470b.png">
