### PR TITLE
fix: Optimize account existance check by using JSON RPC instead of Indexer for Explorer Database as a temporary solution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ async fn playground_ui() -> impl actix_web::Responder {
                   <body>
 
                     <elements-api
-                      apiDescriptionUrl="/api/spec/v3.json"
+                      apiDescriptionUrl="/spec/v3.json"
                       router="hash"
                       layout="sidebar"
                     />
@@ -135,7 +135,7 @@ async fn main() -> std::io::Result<()> {
                 .insert(paperclip::v2::models::OperationProtocol::Https);
             spec.host = Some(api_server_public_host);
         }
-        let base_path = std::env::var("API_BASE_PATH").ok().unwrap_or(String::from(""));
+        let base_path = std::env::var("API_BASE_PATH").unwrap_or_else(|_| "".to_string());
         spec.base_path = Some(base_path.clone());
         spec.info = paperclip::v2::models::Info {
             version: "0.1".into(),

--- a/src/modules/nft/resources.rs
+++ b/src/modules/nft/resources.rs
@@ -30,7 +30,7 @@ pub async fn get_nft_collection_overview(
     types::query_params::check_limit(pagination_params.limit)?;
     types::query_params::check_block_params(&block_params)?;
     let block = db_helpers::get_block_from_params(&pool, &block_params).await?;
-    modules::check_account_exists(&pool, &request.account_id.0, block.timestamp).await?;
+    modules::check_account_exists(&rpc_client, &request.account_id.0, block.height).await?;
 
     Ok(Json(schemas::NftCountsResponse {
         // TODO PHASE 2 We can data_provider metadata in the DB and update once in 10 minutes
@@ -67,7 +67,7 @@ pub async fn get_nft_collection_by_contract(
     types::query_params::check_limit(pagination_params.limit)?;
     types::query_params::check_block_params(&block_params)?;
     let block = db_helpers::get_block_from_params(&pool, &block_params).await?;
-    modules::check_account_exists(&pool, &request.account_id.0, block.timestamp).await?;
+    modules::check_account_exists(&rpc_client, &request.account_id.0, block.height).await?;
     let pagination = types::query_params::Pagination::from(pagination_params.0);
 
     Ok(Json(schemas::NftsResponse {


### PR DESCRIPTION
Ideally, we should index the data so we can check for account existence as fast as possible.