### PR TITLE
feat: change design of get coins endpoint

### DIFF
--- a/src/modules/coin/data_provider/balance.rs
+++ b/src/modules/coin/data_provider/balance.rs
@@ -99,7 +99,10 @@ pub(crate) async fn get_coin_balances_by_contract(
     Ok(vec![coin::schemas::Coin {
         standard: "nep141".to_string(),
         contract_account_id: Some(contract_id.clone().into()),
-        balance: balance.into(),
+        balances: vec![coin::schemas::BalanceItem {
+            symbol: metadata.symbol.clone(),
+            amount: balance.into(),
+        }],
         metadata: coin::schemas::CoinMetadata {
             name: metadata.name,
             symbol: metadata.symbol,
@@ -130,7 +133,10 @@ impl From<coin::schemas::NearBalanceResponse> for coin::schemas::Coin {
     fn from(near_coin: coin::schemas::NearBalanceResponse) -> Self {
         coin::schemas::Coin {
             standard: "nearprotocol".to_string(),
-            balance: near_coin.balance,
+            balances: vec![coin::schemas::BalanceItem {
+                symbol: "NEAR".to_string(),
+                amount: near_coin.balance,
+            }],
             contract_account_id: None,
             metadata: near_coin.metadata,
         }

--- a/src/modules/coin/resources.rs
+++ b/src/modules/coin/resources.rs
@@ -54,8 +54,8 @@ pub async fn get_coin_balances(
     let block = db_helpers::get_block_from_params(&pool, &block_params).await?;
     modules::check_account_exists(&rpc_client, &request.account_id.0, block.height).await?;
 
-    let mut balances: Vec<schemas::Coin> = vec![];
-    balances.push(
+    let mut coins: Vec<schemas::CoinBalancesByContract> = vec![];
+    coins.push(
         data_provider::get_near_balance(&pool, &block, &request.account_id.0)
             .await?
             .into(),
@@ -71,12 +71,12 @@ pub async fn get_coin_balances(
             &pagination,
         )
         .await?;
-        balances.append(ft_balances);
+        coins.append(ft_balances);
         pagination.limit -= ft_balances.length() as u32;
     }
 
     Ok(Json(schemas::CoinBalancesResponse {
-        balances,
+        coins,
         block_timestamp_nanos: types::U64::from(block.timestamp),
         block_height: types::U64::from(block.height),
     }))
@@ -111,7 +111,7 @@ pub async fn get_coin_balances_by_contract(
     let block = db_helpers::get_block_from_params(&pool, &block_params).await?;
     modules::check_account_exists(&rpc_client, &request.account_id.0, block.height).await?;
 
-    let balances = data_provider::get_coin_balances_by_contract(
+    let coins = data_provider::get_coin_balances_by_contract(
         &rpc_client,
         &block,
         &request.contract_account_id.0,
@@ -120,7 +120,7 @@ pub async fn get_coin_balances_by_contract(
     .await?;
 
     Ok(Json(schemas::CoinBalancesResponse {
-        balances,
+        coins,
         block_timestamp_nanos: types::U64::from(block.timestamp),
         block_height: types::U64::from(block.height),
     }))

--- a/src/modules/coin/schemas.rs
+++ b/src/modules/coin/schemas.rs
@@ -59,7 +59,7 @@ pub struct NearBalanceResponse {
 /// For MTs and other standards, balances could have multiple entries for one contract.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
 pub struct CoinBalancesResponse {
-    pub balances: Vec<Coin>,
+    pub coins: Vec<CoinBalancesByContract>,
     pub block_timestamp_nanos: types::U64,
     pub block_height: types::U64,
 }
@@ -87,23 +87,23 @@ pub struct FtContractMetadataResponse {
 /// For MTs and other standards, we could have multiple coins for one contract.
 /// For NEAR and FTs, coin_metadata contains general metadata (the only available option, though).
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
-pub struct Coin {
+pub struct CoinBalancesByContract {
     /// "nearprotocol" for NEAR, "nep141" for FT
     pub standard: String,
     /// For NEAR/FT, there is always 1 item in the list. For MT, there could be more
-    pub balances: Vec<BalanceItem>,
+    pub balances: Vec<Coin>,
     /// null for NEAR, not null otherwise
     pub contract_account_id: Option<types::AccountId>,
-    pub metadata: CoinMetadata,
+    // we can add contract metadata here later if we want
     // TODO PHASE 1 (idea) I think it would be great to add here the info about last update moment. Timestamp, later also index
     // I'm already doing it at NftCount
 }
 
 /// This type describes coin balance information.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
-pub struct BalanceItem {
-    pub symbol: String,
+pub struct Coin {
     pub amount: types::U128,
+    pub metadata: CoinMetadata,
 }
 
 /// This type describes the history of coin movements for the given user.

--- a/src/modules/coin/schemas.rs
+++ b/src/modules/coin/schemas.rs
@@ -90,12 +90,20 @@ pub struct FtContractMetadataResponse {
 pub struct Coin {
     /// "nearprotocol" for NEAR, "nep141" for FT
     pub standard: String,
-    pub balance: types::U128,
+    /// For NEAR/FT, there is always 1 item in the list. For MT, there could be more
+    pub balances: Vec<BalanceItem>,
     /// null for NEAR, not null otherwise
     pub contract_account_id: Option<types::AccountId>,
     pub metadata: CoinMetadata,
     // TODO PHASE 1 (idea) I think it would be great to add here the info about last update moment. Timestamp, later also index
     // I'm already doing it at NftCount
+}
+
+/// This type describes coin balance information.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+pub struct BalanceItem {
+    pub symbol: String,
+    pub amount: types::U128,
 }
 
 /// This type describes the history of coin movements for the given user.


### PR DESCRIPTION
After a discussion with @pkudinov, we came up to the conclusion that we need to change the Coins interface a bit.

We constantly think about the changes that we need to do in the future. In particular, we need to keep in mind that we have Multi Tokens, and we should be able to show multiple balances for one contract.
Initially, we decided to have several items in the response for Multi Tokens.

That gives us the problem with the pagination: we need to create the solution for the case when MT is cut in the middle between 2 pages.

Here, we need to make a step back and remind the nature of MT. I can imagine a few use cases: swapping pools/exchanges, liquidity pools, gaming. For all of them, it makes no sense to show only 1 MT balance. The users (I mean wallet creators) will want to group them. In this case, let's just group them on our side.

With all the advantages of this approach, I see 1 disadvantage - for the majority of use cases, there will be the balances list with just one item inside. And `balances` looks weird when you ask for native/FT balance (why I can get more than 1 balance there). It looks like overengineering to me. But, I anyway vote for these changes.