### PR TITLE
fix: do not filter by timestamp, rename coin_events table

### DIFF
--- a/src/modules/ft/data_provider/balance.rs
+++ b/src/modules/ft/data_provider/balance.rs
@@ -13,7 +13,7 @@ pub(crate) async fn get_ft_balances(
     // todo it's better to query by chunks, this list can bee potentially too big (500+ contracts)
     let query = r"
         SELECT DISTINCT contract_account_id account_id
-        FROM coin_events
+        FROM fungible_token_events
         WHERE affected_account_id = $1
         ORDER BY contract_account_id
     ";


### PR DESCRIPTION
To be consistent, I stopped using timestamp column everywhere


!!! we can't merge it until we finish our perf testing