### PR TITLE
fix: fix type mismatch problem

### DIFF
--- a/src/modules/ft/resources.rs
+++ b/src/modules/ft/resources.rs
@@ -95,7 +95,7 @@ pub async fn get_ft_history(
     _: crate::types::pagoda_api_key::PagodaApiKey,
     request: actix_web_validator::Path<schemas::HistoryRequest>,
     pagination_params: web::Query<types::query_params::PaginationParams>,
-) -> crate::Result<Json<schemas::HistoryResponse>> {
+) -> crate::Result<Json<schemas::FtHistoryResponse>> {
     if request.contract_account_id.to_string() == "near" {
         return Err(errors::ErrorKind::InvalidInput(
             "For native history, please use `/accounts/{account_id}/balances/NEAR/history`"
@@ -107,7 +107,7 @@ pub async fn get_ft_history(
     let block = db_helpers::get_block_from_pagination(&pool_explorer, &pagination).await?;
     // we don't need to check whether account exists. If not, we can just return the empty history
 
-    Ok(Json(schemas::HistoryResponse {
+    Ok(Json(schemas::FtHistoryResponse {
         history: data_provider::get_ft_history(
             &pool_explorer,
             &pool_balances,

--- a/src/modules/ft/schemas.rs
+++ b/src/modules/ft/schemas.rs
@@ -65,7 +65,7 @@ pub struct FtBalance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
-pub struct HistoryResponse {
+pub struct FtHistoryResponse {
     pub history: Vec<HistoryItem>,
     pub block_timestamp_nanos: types::U64,
     pub block_height: types::U64,

--- a/src/modules/native/resources.rs
+++ b/src/modules/native/resources.rs
@@ -39,12 +39,12 @@ pub async fn get_near_history(
     _: crate::types::pagoda_api_key::PagodaApiKey,
     request: actix_web_validator::Path<schemas::BalanceRequest>,
     pagination_params: web::Query<types::query_params::PaginationParams>,
-) -> crate::Result<Json<schemas::HistoryResponse>> {
+) -> crate::Result<Json<schemas::NearHistoryResponse>> {
     let pagination = modules::checked_get_pagination_params(&pagination_params).await?;
     let block = db_helpers::get_block_from_pagination(&pool_explorer, &pagination).await?;
     // we don't need to check whether account exists. If not, we can just return the empty history
 
-    Ok(Json(schemas::HistoryResponse {
+    Ok(Json(schemas::NearHistoryResponse {
         history: data_provider::get_near_history(
             &pool_balances,
             &request.account_id,

--- a/src/modules/native/schemas.rs
+++ b/src/modules/native/schemas.rs
@@ -40,7 +40,7 @@ pub struct NearBalance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
-pub struct HistoryResponse {
+pub struct NearHistoryResponse {
     pub history: Vec<HistoryItem>,
     pub block_timestamp_nanos: types::U64,
     pub block_height: types::U64,

--- a/src/modules/nft/resources.rs
+++ b/src/modules/nft/resources.rs
@@ -132,11 +132,11 @@ pub async fn get_nft_history(
     _: crate::types::pagoda_api_key::PagodaApiKey,
     request: actix_web_validator::Path<schemas::NftRequest>,
     limit_params: web::Query<types::query_params::LimitParams>,
-) -> crate::Result<Json<schemas::HistoryResponse>> {
+) -> crate::Result<Json<schemas::NftHistoryResponse>> {
     let limit = types::query_params::checked_get_limit(limit_params.limit)?;
     let block = db_helpers::get_last_block(&pool_explorer).await?;
 
-    Ok(Json(schemas::HistoryResponse {
+    Ok(Json(schemas::NftHistoryResponse {
         history: super::data_provider::get_nft_history(
             &pool_explorer,
             &request.contract_account_id.0,

--- a/src/modules/nft/schemas.rs
+++ b/src/modules/nft/schemas.rs
@@ -68,7 +68,7 @@ pub struct NftResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
-pub struct HistoryResponse {
+pub struct NftHistoryResponse {
     pub history: Vec<HistoryItem>,
     pub nft: Nft,
     pub block_timestamp_nanos: types::U64,


### PR DESCRIPTION
Paperclip seems to have a bug where its overwriting the return types in the different services (NFT, FT, Native) as they are the same name: `HistoryResponse`. The reason why NFT response type is showing for FT as well as Native History endpoints was because NFT was the last registered service.

I changed the names to unique names now corresponding to their services e.g In FT service `HistoryResponse` -> `FtHistoryResponse`